### PR TITLE
Init module chat service - fix timeout

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -125,7 +125,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "apero-inhouse"
             artifactId = "chat-ai-sdk"
-            version = "0.0.1-alpha11"
+            version = "0.0.1-alpha17"
             from(components["kotlin"])
         }
     }

--- a/service/src/commonMain/kotlin/com/apero/service/AiChatSDK.kt
+++ b/service/src/commonMain/kotlin/com/apero/service/AiChatSDK.kt
@@ -13,6 +13,7 @@ import com.apero.service.logger.Logger
 object AiChatSDK {
 
     const val TAG_FOR_DEBUG = "FOR_TESTER_IN_AiChatSDK: "
+    const val DEFAULT_TIMEOUT_MS = 60_000L
 
     private var baseUrl: String? = null
     private var bundleId: String? = null

--- a/service/src/commonMain/kotlin/com/apero/service/data/remote/model/response/GenImageResponse.kt
+++ b/service/src/commonMain/kotlin/com/apero/service/data/remote/model/response/GenImageResponse.kt
@@ -5,8 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class GenImageResponse(
-    @SerialName("success") val success: Boolean?,
-    @SerialName("message") val message: String?,
     @SerialName("data") val data: GenImageData?,
     @SerialName("timestamp") val timestamp: String?,
     @SerialName("path") val path: String?,

--- a/service/src/commonMain/kotlin/com/apero/service/data/remote/repository/AiChatRepositoryImpl.kt
+++ b/service/src/commonMain/kotlin/com/apero/service/data/remote/repository/AiChatRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.apero.service.domain.model.ChatAnswerData
 import com.apero.service.domain.model.GenImageResult
 import com.apero.service.domain.model.GenImageStyleModel
 import com.apero.service.domain.repository.AiChatRepository
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -135,6 +136,7 @@ internal class AiChatRepositoryImpl(
             }
             .collect { response ->
                 message += response.message
+                delay(10L)
                 trySend(ChatAnswerData.Answering(conversationId, message))
             }
 

--- a/service/src/commonMain/kotlin/com/apero/service/network/HttpClientProvider.kt
+++ b/service/src/commonMain/kotlin/com/apero/service/network/HttpClientProvider.kt
@@ -1,10 +1,12 @@
 package com.apero.service.network
 
 import com.apero.service.AiChatSDK
+import com.apero.service.AiChatSDK.DEFAULT_TIMEOUT_MS
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngineConfig
 import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
@@ -37,8 +39,13 @@ internal fun <T : HttpClientEngineConfig> createBaseHttpClient(
                 encodeDefaults = true
             })
         }
+        install(HttpTimeout) {
+            requestTimeoutMillis = DEFAULT_TIMEOUT_MS
+            connectTimeoutMillis = DEFAULT_TIMEOUT_MS
+            socketTimeoutMillis = DEFAULT_TIMEOUT_MS
+        }
         install(Logging) {
-            level = LogLevel.ALL
+            level = LogLevel.HEADERS
         }
 
         this.block()


### PR DESCRIPTION
- Add DEFAULT_TIMEOUT_MS constant.
- Configure HttpTimeout with default timeout values for request, connect, and socket.
- Change logging level from ALL to HEADERS.
- Remove success and message fields from GenImageResponse.
- Add a small delay in AiChatRepositoryImpl when collecting chat responses.